### PR TITLE
Remove codacy badge in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Concolor
 
 [![ci status](https://github.com/metarhia/concolor/workflows/Testing%20CI/badge.svg)](https://github.com/metarhia/concolor/actions?query=workflow%3A%22Testing+CI%22+branch%3Amaster)
-[![codacy](https://api.codacy.com/project/badge/Grade/6f4f133090d64f178d099f86521ec117)](https://www.codacy.com/app/metarhia/concolor)
 [![snyk](https://snyk.io/test/github/metarhia/impress/badge.svg)](https://snyk.io/test/github/metarhia/impress)
 [![npm version](https://badge.fury.io/js/concolor.svg)](https://badge.fury.io/js/concolor)
 [![npm downloads/month](https://img.shields.io/npm/dm/concolor.svg)](https://www.npmjs.com/package/concolor)


### PR DESCRIPTION
- [x] tests and linter show no problems (`npm t`)
- [x] code is properly formatted (`npm run fmt`)

